### PR TITLE
Update integrations.md, Remove servicenow and rocket.chat

### DIFF
--- a/content/docs/operating/integrations.md
+++ b/content/docs/operating/integrations.md
@@ -92,8 +92,6 @@ For notification mechanisms not natively supported by the Alertmanager, the
   * [Phabricator / Maniphest](https://github.com/knyar/phalerts)
   * [prom2teams](https://github.com/idealista/prom2teams): forwards notifications to Microsoft Teams
   * [Ansible Tower](https://github.com/pja237/prom2tower): call Ansible Tower (AWX) API on alerts (launch jobs etc.)
-  * [Rocket.Chat](https://rocket.chat/docs/administrator-guides/integrations/prometheus/)
-  * [ServiceNow](https://github.com/FXinnovation/alertmanager-webhook-servicenow)
   * [Signal](https://github.com/dgl/alertmanager-webhook-signald)
   * [SIGNL4](https://www.signl4.com/blog/portfolio_item/prometheus-alertmanager-mobile-alert-notification-duty-schedule-escalation)
   * [SMS](https://github.com/messagebird/sachet): supports [multiple providers](https://github.com/messagebird/sachet/blob/master/examples/config.yaml)


### PR DESCRIPTION
1. Removed servicenow integartion link due to it resulting in a 404, as the repo does not seem to exist anymore.
2. Removed rocket.chat webhook integration link, as it leads to a link of monitoring rocket.chat with prometheus, and not integrating alertmanager with rocket.chat as a receiver.